### PR TITLE
Дополнена функция createHash выбором алгоритма

### DIFF
--- a/src/api/createHash.ts
+++ b/src/api/createHash.ts
@@ -3,15 +3,16 @@ import { _extractMeaningfulErrorMessage } from '../helpers/_extractMeaningfulErr
 import { __cadesAsyncToken__, __createCadesPluginObject__, _generateCadesFn } from '../helpers/_generateCadesFn';
 
 /**
- * Создает хеш сообщения по ГОСТ Р 34.11-2012 256 бит
+ * Создает хеш сообщения по ГОСТ Р 34.11-2012 (по умолчанию 256 бит)
  * https://ru.wikipedia.org/wiki/%D0%A1%D1%82%D1%80%D0%B8%D0%B1%D0%BE%D0%B3_(%D1%85%D0%B5%D1%88-%D1%84%D1%83%D0%BD%D0%BA%D1%86%D0%B8%D1%8F)
  *
  * @param unencryptedMessage - сообщение для хеширования
+ * @hashedAlgorithm - алгоритм хеширования. По умолчанию - CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256.
  *
  * @returns хеш
  */
 export const createHash = _afterPluginsLoaded(
-  async (unencryptedMessage: string | ArrayBuffer): Promise<string> => {
+  async (unencryptedMessage: string | ArrayBuffer, hashedAlgorithm?: number): Promise<string> => {
     const { cadesplugin } = window;
 
     return eval(
@@ -31,7 +32,9 @@ export const createHash = _afterPluginsLoaded(
         try {
           void (
             __cadesAsyncToken__ +
-            cadesHashedData.propset_Algorithm(cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256)
+            cadesHashedData.propset_Algorithm(
+              hashedAlgorithm ?? cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256,
+            )
           );
           void (__cadesAsyncToken__ + cadesHashedData.propset_DataEncoding(cadesplugin.CADESCOM_BASE64_TO_BINARY));
           void (__cadesAsyncToken__ + cadesHashedData.Hash(messageBase64));


### PR DESCRIPTION
На текущий момент функция `createHash` принимает на вход только `unencryptedMessage` и всегда возвращает хеш по ГОСТ 256 бит.

В наших проектах иногда необходимо работать с strong-версиями хеширования и шифрования, поэтому предлагается добавить в `createHash` второй необязательный аргумент - тип алгоритма хеширования.
По умолчанию всё как и было - 256 бит, но теперь это можно переопределить.