### PR TITLE
Добавление объекта options для поддержки detached и xml подписей 512 бит

### DIFF
--- a/examples/script-tag/public/index.html
+++ b/examples/script-tag/public/index.html
@@ -49,7 +49,7 @@
 
         <fieldset>
             <legend>Результат</legend>
-            <label for="hash">Хеш (ГОСТ Р 34.11-2012 256 бит):</label><br>
+            <label for="hash">Хеш (ГОСТ Р 34.11-2012):</label><br>
             <textarea id="hash" cols="80" rows="5" placeholder="Не вычислен"></textarea>
             <br>
             <pre id="hashError"></pre>

--- a/src/api/createDetachedSignature.ts
+++ b/src/api/createDetachedSignature.ts
@@ -5,15 +5,26 @@ import { __cadesAsyncToken__, __createCadesPluginObject__, _generateCadesFn } fr
 import { _getCadesCert } from '../helpers/_getCadesCert';
 import { _getDateObj } from '../helpers/_getDateObj';
 
+/** Дополнительные настройки */
+type Options = {
+  /**
+   * Алгоритм хеширования
+   *
+   * @defaultValue `cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256`
+   */
+  hashedAlgorithm?: number;
+};
+
 /**
  * Создает отсоединенную подпись хеша по отпечатку сертификата
  *
  * @param thumbprint - отпечаток сертификата
- * @param messageHash - хеш подписываемого сообщения, сгенерированный по ГОСТ Р 34.11-2012 256 бит
+ * @param messageHash - хеш подписываемого сообщения, сгенерированный по ГОСТ Р 34.11-2012 256 или 512 бит в зависимости от алгоритма открытого ключа
+ * @param options - дополнительные настройки
  * @returns подпись в формате PKCS#7
  */
 export const createDetachedSignature = _afterPluginsLoaded(
-  async (thumbprint: string, messageHash: string): Promise<string> => {
+  async (thumbprint: string, messageHash: string, options?: Options): Promise<string> => {
     const { cadesplugin } = window;
     const cadesCertificate = await _getCadesCert(thumbprint);
 
@@ -62,7 +73,9 @@ export const createDetachedSignature = _afterPluginsLoaded(
         try {
           void (
             __cadesAsyncToken__ +
-            cadesHashedData.propset_Algorithm(cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256)
+            cadesHashedData.propset_Algorithm(
+              options?.hashedAlgorithm ?? cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256,
+            )
           );
           void (__cadesAsyncToken__ + cadesHashedData.SetHashValue(messageHash));
         } catch (error) {

--- a/src/api/createHash.ts
+++ b/src/api/createHash.ts
@@ -3,8 +3,19 @@ import { _afterPluginsLoaded } from '../helpers/_afterPluginsLoaded';
 import { _extractMeaningfulErrorMessage } from '../helpers/_extractMeaningfulErrorMessage';
 import { __cadesAsyncToken__, __createCadesPluginObject__, _generateCadesFn } from '../helpers/_generateCadesFn';
 
+/** Дополнительные настройки */
 type Options = {
+  /**
+   * Алгоритм хеширования
+   *
+   * @defaultValue `cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256`
+   */
   hashedAlgorithm?: number;
+  /**
+   * Кодировка сообщения для хеширования
+   *
+   * @defaultValue `utf8`
+   */
   encoding?: TranscodeEncoding;
 };
 
@@ -13,7 +24,7 @@ type Options = {
  * https://ru.wikipedia.org/wiki/%D0%A1%D1%82%D1%80%D0%B8%D0%B1%D0%BE%D0%B3_(%D1%85%D0%B5%D1%88-%D1%84%D1%83%D0%BD%D0%BA%D1%86%D0%B8%D1%8F)
  *
  * @param unencryptedMessage - сообщение для хеширования
- * @hashedAlgorithm - алгоритм хеширования. По умолчанию - CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256.
+ * @options - дополнительные настройки
  *
  * @returns хеш
  */

--- a/src/api/createXMLSignature.ts
+++ b/src/api/createXMLSignature.ts
@@ -3,15 +3,33 @@ import { _extractMeaningfulErrorMessage } from '../helpers/_extractMeaningfulErr
 import { __cadesAsyncToken__, __createCadesPluginObject__, _generateCadesFn } from '../helpers/_generateCadesFn';
 import { _getCadesCert } from '../helpers/_getCadesCert';
 
+/** Дополнительные настройки */
+type Options = {
+  /**
+   * Метод подписи
+   *
+   * @defaultValue `cadesplugin.XmlDsigGost3410Url2012256`
+   */
+  signatureMethod?: string;
+  /**
+   * Метод формирования дайджеста
+   *
+   * @defaultValue `cadesplugin.XmlDsigGost3411Url2012256`
+   */
+  digestMethod?: string;
+};
+
 /**
  * Создает XML подпись для документа в формате XML
  *
  * @param thumbprint - отпечаток сертификата
  * @param unencryptedMessage - подписываемое сообщение в формате XML
+ * @options - дополнительные настройки
+ *
  * @returns подпись
  */
 export const createXMLSignature = _afterPluginsLoaded(
-  async (thumbprint: string, unencryptedMessage: string): Promise<string> => {
+  async (thumbprint: string, unencryptedMessage: string, options?: Options): Promise<string> => {
     const { cadesplugin } = window;
     const cadesCertificate = await _getCadesCert(thumbprint);
 
@@ -30,8 +48,8 @@ export const createXMLSignature = _afterPluginsLoaded(
         }
 
         try {
-          const signatureMethod = 'urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr34102012-gostr34112012-256';
-          const digestMethod = 'urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr34112012-256';
+          const signatureMethod = options?.signatureMethod ?? cadesplugin.XmlDsigGost3410Url2012256;
+          const digestMethod = options?.digestMethod ?? cadesplugin.XmlDsigGost3411Url2012256;
 
           void (__cadesAsyncToken__ + cadesSigner.propset_Certificate(cadesCertificate));
           void (__cadesAsyncToken__ + cadesSigner.propset_CheckCertificate(true));


### PR DESCRIPTION
В этом PR выполнены следующие улучшения:

1. Добавлен необязательный аргумент `options` в `createDetachedSignature` и `createXMLSignature` по аналогии с `createHash` из последнего релиза. Пока там содержатся только опции для поддержки сертификатов по алгоритмам ГОСТ 512 бит.
2. Исправлено описание `createHash`.
3. Дополнено тестовое приложение, чтобы срабатывала подпись при помощи ЭП с алгоритмом 512 бит.
 
По п.3. Пришлось немного "пошаманить" с определением алгоритма в сертификате ЭП.
Думал положить код определения алгоритма внутри функций `createDetachedSignature` и `createXMLSignature`, но решил это сделать снаружи.
Также заметил, что соединённая подпись уже работает корректно, т.к. для её работы не нужно жёстко указывать алгоритмы подписи и/или хеширования.
