### PR TITLE
Экспортирование константы наружу

### DIFF
--- a/src/crypto-pro.ts
+++ b/src/crypto-pro.ts
@@ -1,1 +1,2 @@
 export * from './api';
+export * from './constants';


### PR DESCRIPTION
Для получения значения данных констант требуется прописывать их вручную, так как сейчас в бандле остаются только `d.ts` файлы с `export declare const`, что не даёт использовать данные переменные